### PR TITLE
Fix some lints

### DIFF
--- a/src/basictables.rs
+++ b/src/basictables.rs
@@ -76,7 +76,7 @@ pub fn compile_head(font: &babelfont::Font, glyf: &glyf::glyf) -> head {
 
     let created_date = font.date.naive_local();
 
-    let head_table = head {
+    head {
         checksumAdjustment: 0,
         created: created_date,
         flags: head_flags(font),
@@ -99,9 +99,7 @@ pub fn compile_head(font: &babelfont::Font, glyf: &glyf::glyf) -> head {
         xMin: x_min,
         yMax: y_max,
         yMin: y_min,
-    };
-
-    head_table
+    }
 }
 
 pub fn compile_post(font: &babelfont::Font, glyph_names: &[String]) -> post {
@@ -404,7 +402,7 @@ pub fn compile_os2(
     if let Some(OTScalar::BitField(page_ranges)) = input.ot_value("OS2", "codePageRanges", true) {
         table.int_list_to_code_page_ranges(&page_ranges);
     } else {
-        table.calc_code_page_ranges(&mapping);
+        table.calc_code_page_ranges(mapping);
     }
     table
 }

--- a/src/fontinfo.rs
+++ b/src/fontinfo.rs
@@ -65,7 +65,7 @@ pub fn style_map_family_name(input: &babelfont::Font) -> String {
             let mut res = String::new();
             res.push_str(&family_name);
             if !lower.is_empty() {
-                res.push_str(&" ".to_string());
+                res.push(' ');
                 res.push_str(&style_name.unwrap());
             }
             res
@@ -80,7 +80,7 @@ pub fn style_map_style_name(input: &babelfont::Font) -> String {
         Some(StyleMapStyle::Italic) => "italic",
         Some(StyleMapStyle::Regular) => "regular",
         None => {
-            let preferred_style_name = preferred_subfamily_name(&input);
+            let preferred_style_name = preferred_subfamily_name(input);
             match preferred_style_name.to_lowercase().as_str() {
                 "bold italic" => "bold italic",
                 "bold" => "bold",

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -106,7 +106,7 @@ pub fn layers_to_glyph(
         let all_contours: Vec<&babelfont::Path> = layers
             .iter()
             .filter(|g| g.is_some())
-            .map(|x| x.unwrap().paths().skip(index).next().unwrap())
+            .map(|x| x.unwrap().paths().nth(index).unwrap())
             .collect();
 
         // Convert them together into OT contours

--- a/src/kerning.rs
+++ b/src/kerning.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use babelfont::Font;
 use fonttools::layout::common::{
     FeatureList, LanguageSystem, Lookup, LookupFlags, Script, ScriptList,
@@ -5,17 +7,8 @@ use fonttools::layout::common::{
 use fonttools::layout::gpos2::{PairPos, PairPositioningMap};
 use fonttools::tables::GPOS::{Positioning, GPOS};
 use fonttools::tag;
-use otspec::layout::common::FeatureRecord;
 use otspec::layout::valuerecord::ValueRecord;
 use otspec::valuerecord;
-use std::collections::BTreeMap;
-use std::iter::FromIterator;
-
-macro_rules! hashmap {
-        ($($k:expr => $v:expr),* $(,)?) => {
-            std::collections::BTreeMap::<_, _>::from_iter(std::array::IntoIter::new([$(($k, $v),)*]))
-        };
-    }
 
 pub fn build_kerning(font: &Font, mapping: &BTreeMap<String, u16>) -> GPOS {
     let master = font.default_master().unwrap();
@@ -52,17 +45,16 @@ pub fn build_kerning(font: &Font, mapping: &BTreeMap<String, u16>) -> GPOS {
             rule: Positioning::Pair(vec![pairpos]),
         }],
         scripts: ScriptList {
-            scripts: hashmap!(tag!("DFLT") => Script {
-                default_language_system: Some(
-                    LanguageSystem {
+            scripts: BTreeMap::from([(
+                tag!("DFLT"),
+                Script {
+                    default_language_system: Some(LanguageSystem {
                         required_feature: None,
-                        feature_indices: vec![
-                            0,
-                       ],
-                    },
-                ),
-                language_systems: BTreeMap::new()
-            }),
+                        feature_indices: vec![0],
+                    }),
+                    language_systems: BTreeMap::new(),
+                },
+            )]),
         },
         features: FeatureList::new(vec![(tag!("kern"), vec![0], None)]),
     }


### PR DESCRIPTION
Some lints found with `cargo fmt && cargo clippy --all-targets --all-features -- -D warnings`. One last lint remains because babelfont::Layer::components does not return a double-ended iterator, which `rev()` needs.