### PR TITLE
Sort cmap subtables as per the spec

### DIFF
--- a/src/basictables.rs
+++ b/src/basictables.rs
@@ -191,6 +191,11 @@ pub fn compile_cmap(
             uvs_mapping: Some(uvs_mapping),
         })
     }
+
+    // The specification demands the following sorting, see
+    // https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#encoding-records-and-encodings.
+    subtables.sort_by_key(|s| (s.platformID, s.encodingID, s.languageID));
+
     cmap::cmap { subtables }
 }
 


### PR DESCRIPTION
Stolen from https://github.com/fonttools/fonttools/blob/da52dc30941c3645c7ba9ca56574d59d13c1ebba/Lib/fontTools/ttLib/tables/_c_m_a_p.py#L311-L326.

OTS is still angry:

```
ERROR: cmap: format 12 subtable group endCharCode before startCharCode (0x   C < 0x   D)
ERROR: cmap: Failed to parse format 12 cmap subtable 1
ERROR: cmap: Failed to parse table
Failed to sanitize file!
```